### PR TITLE
Remove useless plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,0 @@
-name: DistanceExpansion
-version: '1.0'
-main: cn.clexus.distancePlaceholderAPIExpansion.DistanceExpansion
-api-version: '1.21'


### PR DESCRIPTION
Expansions aren't plugins.
They don't need a plugin.yml to function as they are loaded from a folder in PlaceholderAPI.